### PR TITLE
fix: Don't process empty messages

### DIFF
--- a/src/games/kalambury/Kalambury.js
+++ b/src/games/kalambury/Kalambury.js
@@ -48,10 +48,13 @@ function LogAction(G, ctx, playerID, action, params = {}, clear = false) {
 }
 
 function SendText(G, ctx, text) {
+  if (!stripPhrase(text)) return;
   LogAction(G, ctx, ctx.playerID, "message", { text: text });
 }
 
 function Guess(G, ctx, phrase) {
+  if (!stripPhrase(phrase)) return;
+
   let success = stripPhrase(phrase).includes(stripPhrase(G.secret.phrase));
 
   if (success) {

--- a/src/games/kalambury/board/GuessingBoard.js
+++ b/src/games/kalambury/board/GuessingBoard.js
@@ -21,7 +21,7 @@ const GuessingBoard = ({
   const { t } = useTranslation("kalambury");
 
   const sendGuess = () => {
-    Guess(guess);
+    if (guess) Guess(guess);
     setGuess("");
   };
 

--- a/src/games/kalambury/board/WaitingBoard.js
+++ b/src/games/kalambury/board/WaitingBoard.js
@@ -18,7 +18,7 @@ const WaitingBoard = ({
     setGuess(e.target.value);
   };
   const sendGuess = () => {
-    SendText(guess);
+    if (guess) SendText(guess);
     setGuess("");
   };
 


### PR DESCRIPTION
Closes #30 

Should we also strip whitespace in react or is current implementation ok? Right now if you type only spaces it will be sent as a move, but won't be processed by game engine.