### PR TITLE
Fix changing phrase

### DIFF
--- a/src/games/kalambury/board/GameBoard.js
+++ b/src/games/kalambury/board/GameBoard.js
@@ -71,6 +71,11 @@ const GameBoard = ({
     if (isDrawing) moves.UpdateDrawing(lines);
   }, [isDrawing, moves, lines]);
 
+  const handleChangePhrase = () => {
+    ChangePhrase();
+    setLines([]);
+  };
+
   return (
     <>
       {isDrawing ? (
@@ -91,11 +96,7 @@ const GameBoard = ({
       </Header>
       {isDrawing && (
         <Segment basic textAlign="center">
-          <Button
-            color="yellow"
-            disabled={!canChangePhrase}
-            onClick={() => setLines([]) && ChangePhrase()}
-          >
+          <Button color="yellow" disabled={!canChangePhrase} onClick={handleChangePhrase}>
             {t("board.game.new_phrase")}
           </Button>
         </Segment>


### PR DESCRIPTION
Closes #45 

```javascript
<Button ... onClick={() => setLines([]) && ChangePhrase()}>
     {t("board.game.new_phrase")}
</Button>
```
`setSth` functions return nothing (`undefined`) so `ChangePhrase()` is never executed