### PR TITLE
Fix reversed color

### DIFF
--- a/src/games/kalambury/board/GameBoard.js
+++ b/src/games/kalambury/board/GameBoard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Segment, Button, Header } from "semantic-ui-react";
 import Confetti from "react-dom-confetti";
+import { shuffle } from "lodash";
 import { withTranslation } from "react-i18next";
 import { timerFormat } from "../utils/time";
 import DrawingBoard from "./DrawingBoard";
@@ -17,7 +18,7 @@ const confettiConfig = {
   stagger: 0,
   width: "10px",
   height: "43px",
-  colors: COLORS.sort((a, b) => Math.random()).slice(0, 5),
+  colors: shuffle(COLORS).slice(0, 5),
 };
 
 const GameBoard = ({
@@ -71,6 +72,11 @@ const GameBoard = ({
     if (isDrawing) moves.UpdateDrawing(lines);
   }, [isDrawing, moves, lines]);
 
+  const handleChangePhrase = () => {
+    ChangePhrase();
+    setLines([]);
+  };
+
   return (
     <>
       {isDrawing ? (
@@ -91,11 +97,7 @@ const GameBoard = ({
       </Header>
       {isDrawing && (
         <Segment basic textAlign="center">
-          <Button
-            color="yellow"
-            disabled={!canChangePhrase}
-            onClick={() => setLines([]) && ChangePhrase()}
-          >
+          <Button color="yellow" disabled={!canChangePhrase} onClick={handleChangePhrase}>
             {t("board.game.new_phrase")}
           </Button>
         </Segment>


### PR DESCRIPTION
Closes #49 

It was caused by this line in `confettConfig`:
```javascript
COLORS.sort((a, b) => Math.random())
```
1. `sort` mutates original array 
2. `sort` with `Math.random()` doesnt really shuffle an array
> 1.If compare (a,b) is less than zero, the sort( ) method sorts a to a lower index than b. In other words, a will come first.
2.If compare (a,b) is greater than zero, the sort( ) method sort b to a lower index than a, i.e., b will come first.
3.If compare (a,b) returns zero, the sort ( ) method considers a equals b and leaves their positions unchanged.