### PR TITLE
Remove relative imports

### DIFF
--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useMemo, useCallback, useContext } from "react";
 
-import { UserClient } from "../services/User";
+import { UserClient } from "services/User";
 
 const defaultContext = {
   user: null,


### PR DESCRIPTION
Closes #31

I'd leave imports within the game directory relative if they reference the same game components