### PR TITLE
Prevent infinite components remounting

### DIFF
--- a/src/components/lobby/Lobby.js
+++ b/src/components/lobby/Lobby.js
@@ -29,7 +29,7 @@ const Lobby = ({
     noRoomImage: { margin: "0 auto" },
   };
 
-  const CreateRoomSegment = () => (
+  const createRoomSegment = () => (
     <Segment>
       <Header as="h3" textAlign="center">
         {t("create.title")}
@@ -43,7 +43,7 @@ const Lobby = ({
     </Segment>
   );
 
-  const RoomsListSegment = () => (
+  const roomsListSegment = () => (
     <Segment>
       <Header as="h3" textAlign="center">
         {t("list.title")}
@@ -76,25 +76,17 @@ const Lobby = ({
   return (
     <Container>
       <Responsive as={Grid} minWidth={Responsive.onlyComputer.minWidth}>
-        <Grid.Column width="12">
-          <RoomsListSegment />
-        </Grid.Column>
-        <Grid.Column width="4">
-          <CreateRoomSegment />
-        </Grid.Column>
+        <Grid.Column width="12">{roomsListSegment()}</Grid.Column>
+        <Grid.Column width="4">{createRoomSegment()}</Grid.Column>
       </Responsive>
       <Responsive as={Grid} maxWidth={Responsive.onlyTablet.maxWidth}>
         {!currentRoom && (
           <Grid.Row>
-            <Grid.Column>
-              <CreateRoomSegment />
-            </Grid.Column>
+            <Grid.Column>{createRoomSegment()}</Grid.Column>
           </Grid.Row>
         )}
         <Grid.Row>
-          <Grid.Column>
-            <RoomsListSegment />
-          </Grid.Column>
+          <Grid.Column>{roomsListSegment()}</Grid.Column>
         </Grid.Row>
       </Responsive>
     </Container>

--- a/src/games/kalambury/Board.js
+++ b/src/games/kalambury/Board.js
@@ -59,7 +59,7 @@ const Board = ({ G, ctx, playerID, moves, gameMetadata, rawClient }) => {
     }
   };
 
-  let GameContent = () => (
+  let gameContent = () => (
     <>
       <Header as="h2" textAlign="center">
         {t(`header.${phase}`)}
@@ -96,7 +96,7 @@ const Board = ({ G, ctx, playerID, moves, gameMetadata, rawClient }) => {
     </>
   );
 
-  const SidebarContent = () => (
+  const sidebarContent = () => (
     <Sidebar
       handleGuessClick={handleGuessClick}
       getUserActions={getUserActions}
@@ -113,26 +113,18 @@ const Board = ({ G, ctx, playerID, moves, gameMetadata, rawClient }) => {
       </Segment>
       <Responsive as={Grid} minWidth={Responsive.onlyComputer.minWidth}>
         <Grid.Column width="12">
-          <Grid.Row>
-            <GameContent />
-          </Grid.Row>
+          <Grid.Row>{gameContent()}</Grid.Row>
         </Grid.Column>
         <Grid.Column width="4">
-          <Grid.Row>
-            <SidebarContent />
-          </Grid.Row>
+          <Grid.Row>{sidebarContent()}</Grid.Row>
         </Grid.Column>
       </Responsive>
       <Responsive as={Grid} maxWidth={Responsive.onlyTablet.maxWidth}>
         <Grid.Row>
-          <Grid.Column>
-            <GameContent />
-          </Grid.Column>
+          <Grid.Column>{gameContent()}</Grid.Column>
         </Grid.Row>
         <Grid.Row>
-          <Grid.Column>
-            <SidebarContent />
-          </Grid.Column>
+          <Grid.Column>{sidebarContent()}</Grid.Column>
         </Grid.Row>
       </Responsive>
     </Container>

--- a/src/games/kalambury/board/DrawingBoard.js
+++ b/src/games/kalambury/board/DrawingBoard.js
@@ -1,15 +1,13 @@
 import React from "react";
 import DrawArea from "../DrawArea";
 
-const DrawingBoard = ({ G: { remainingSeconds }, moves: { Forfeit }, lines, setLines }) => {
-  return (
-    <DrawArea
-      remainingSeconds={remainingSeconds}
-      onForfeit={() => Forfeit()}
-      lines={lines}
-      setLines={setLines}
-    />
-  );
-};
+const DrawingBoard = ({ G: { remainingSeconds }, moves: { Forfeit }, lines, setLines }) => (
+  <DrawArea
+    remainingSeconds={remainingSeconds}
+    onForfeit={() => Forfeit()}
+    lines={lines}
+    setLines={setLines}
+  />
+);
 
 export default DrawingBoard;


### PR DESCRIPTION
Fixes #81 

I don't exactly understand the mechanism behind this, but apparently the way we use local components make a big difference to react in terms of components redrawing. Some details can be found here https://www.huy.dev/2017-01-avoid-unnecessary-remounting-react/

Using component like this: `<GameContent />` caused it to be constantly remounted. Changing it to `{GameContent()}` seems to resolve the issue.