### PR TITLE
Fetch user profiles as one document

### DIFF
--- a/src/config/propTypes.js
+++ b/src/config/propTypes.js
@@ -3,7 +3,7 @@ import { string, arrayOf, shape, object, number, bool } from "prop-types";
 export const RoomType = shape({
   gameID: string.isRequired,
   gameName: string.isRequired,
-  players: arrayOf(shape({ id: string.isRequired, name: string })).isRequired,
+  players: arrayOf(shape({ id: number.isRequired, name: string })).isRequired,
   setupData: object,
 });
 

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -33,7 +33,7 @@ export const UserProvider = ({ children }) => {
 
   useEffect(() => {
     const unsubscribe = DataStore.subscribeProfiles((profiles) => {
-      setProfiles(profilesMap(profiles));
+      setProfiles(profilesMap(Object.entries(profiles)));
     });
     return () => unsubscribe();
   }, [setProfiles]);

--- a/src/services/DataStore.js
+++ b/src/services/DataStore.js
@@ -2,16 +2,15 @@ import FirebaseClient from "./Firebase";
 
 const DB = FirebaseClient.firestore();
 
+console.log(DB);
+
 const DataStore = {
   // Public users' profiles
-  profiles: DB.collection("public_profiles"),
-  fetchProfile: async (uid) => await DataStore.profiles.doc(uid).get(),
-  updateProfile: async (uid, profileData) => await DataStore.profiles.doc(uid).set(profileData),
+  profiles: DB.collection("users").doc("public_profiles"),
+  updateProfile: async (uid, profileData) =>
+    await DataStore.profiles.update({ [uid]: profileData }),
   subscribeProfiles: (callback) => {
-    return DataStore.profiles.onSnapshot((snapshot) => {
-      const profiles = snapshot.docs.map((doc) => [doc.id, doc.data()]);
-      callback(profiles);
-    });
+    return DataStore.profiles.onSnapshot((doc) => callback(doc.data()));
   },
   // Game credentials
   credentials: DB.collection("game_credentials"),


### PR DESCRIPTION
Before we stored each user profile in a separate document which resulted in lot's of db reads.

Right now we are storing them in one doc, and limiting update rules to allow changing only the data that belongs to authenticated user 

Closes #96 